### PR TITLE
Update requirements.txt

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -2,3 +2,4 @@ sphinx-rtd-theme
 sphinx
 recommonmark
 sphinxcontrib-bibtex
+breathe


### PR DESCRIPTION
The python breathe was missing

Seems like the build did not pass: https://readthedocs.org/projects/ilfreddy-mrchem/builds/6303621/, despite the fact that it is shown as passed here: https://readthedocs.org/projects/ilfreddy-mrchem/builds/