### PR TITLE
ExchangePotential D1 and D2 parallelized using bank

### DIFF
--- a/src/input/template.yml
+++ b/src/input/template.yml
@@ -166,7 +166,7 @@ sections:
           This will use MPI shared memory for the exchange-correlation potential.
       - name: bank_size
         type: int
-        default: 0
+        default: -1
         docstring: |
           Number of MPI processes exclusively dedicated to manage orbital bank.
   - name: Basis

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -30,7 +30,7 @@ int sh_group_rank = 0;
 int is_bank = 0;
 int is_bankclient = 1;
 int is_bankmaster = 0; // only one bankmaster is_bankmaster
-int bank_size = 0;
+int bank_size = -1;
 std::vector<int> bankmaster;
 
 MPI_Comm comm_orb;
@@ -59,7 +59,8 @@ void mpi::initialize() {
     // for now the new group does not include comm_share
     mpi::comm_bank = MPI_COMM_WORLD; // clients and master
     MPI_Comm comm_remainder;         // clients only
-
+    if (mpi::world_size > 1 and mpi::bank_size < 0) mpi::bank_size = mpi::world_size / 6 + 1;
+    mpi::bank_size = std::max(0, mpi::bank_size);
     if (mpi::world_size - mpi::bank_size < 1) MSG_ABORT("No MPI ranks left for working!");
     mpi::bankmaster.resize(mpi::bank_size);
     for (int i = 0; i < mpi::bank_size; i++) {
@@ -105,6 +106,8 @@ void mpi::initialize() {
         MPI_Finalize();
         exit(EXIT_SUCCESS);
     }
+#else
+    mpi_bank_size = 0;
 #endif
 }
 
@@ -659,7 +662,7 @@ void Bank::clear_bank() {
 
 void Bank::clear(int ix) {
 #ifdef HAVE_MPI
-    delete deposits[ix].orb;
+    deposits[ix].orb->free(NUMBER::Total);
     delete deposits[ix].data;
     deposits[ix].hasdata = false;
 #endif

--- a/src/qmoperators/two_electron/ExchangePotential.cpp
+++ b/src/qmoperators/two_electron/ExchangePotential.cpp
@@ -126,6 +126,10 @@ Orbital ExchangePotential::apply(Orbital inp) {
     }
     int i = testPreComputed(inp);
     if (i < 0) {
+        if (!mpi::my_orb(inp)) {
+            MSG_WARN("Not computing exchange contributions that are not mine");
+            return inp.paramCopy();
+        }
         println(4, "On-the-fly exchange");
         return calcExchange(inp);
     } else {

--- a/src/qmoperators/two_electron/ExchangePotentialD1.cpp
+++ b/src/qmoperators/two_electron/ExchangePotentialD1.cpp
@@ -53,9 +53,9 @@ void ExchangePotentialD1::setupInternal(double prec) {
             Orbital &phi_i = iter.orbital(0);
             int idx = iter.idx(0);
             for (int j = 0; j < Phi.size(); j++) {
+                if (mpi::my_orb(phi_i) and j <= idx) continue; // compute only i<j for own block
                 Orbital &phi_j = (*this->orbitals)[j];
-                if (idx == j) continue; // skip diagonal terms
-                if (mpi::my_orb(phi_i) and mpi::my_orb(phi_j)) calcInternal(idx, j);
+                if (mpi::my_orb(phi_j)) calcInternal(idx, j, phi_i, phi_j);
             }
             // must send exchange_i to owner and receive exchange computed by other
             if (iter.get_step(0) and not mpi::my_orb(phi_i))
@@ -129,45 +129,42 @@ int ExchangePotentialD1::testPreComputed(Orbital phi_p) const {
  */
 Orbital ExchangePotentialD1::calcExchange(Orbital phi_p) {
     Timer timer;
-
     double prec = this->apply_prec;
     OrbitalVector &Phi = *this->orbitals;
     mrcpp::PoissonOperator &P = *this->poisson;
-
     std::vector<std::complex<double>> coef_vec;
     QMFunctionVector func_vec;
 
-    OrbitalIterator iter(Phi);
-    while (iter.next()) {
-        for (int i = 0; i < iter.get_size(); i++) {
-            Orbital &phi_i = iter.orbital(i);
+    for (int i = 0; i < Phi.size(); i++) {
+        Orbital &phi_i = Phi[i];
+        if (!mpi::my_orb(phi_i)) mpi::orb_bank.get_orb(i, phi_i);
+        double spin_fac = getSpinFactor(phi_i, phi_p);
+        if (std::abs(spin_fac) < mrcpp::MachineZero) continue;
 
-            double spin_fac = getSpinFactor(phi_i, phi_p);
-            if (std::abs(spin_fac) < mrcpp::MachineZero) continue;
+        // compute phi_ip = phi_i^dag * phi_p
+        Orbital phi_ip = phi_p.paramCopy();
+        qmfunction::multiply(phi_ip, phi_i, phi_p, -1.0);
 
-            // compute phi_ip = phi_i^dag * phi_p
-            Orbital phi_ip = phi_p.paramCopy();
-            qmfunction::multiply(phi_ip, phi_i, phi_p, -1.0);
-
-            // compute V_ip = P[phi_ip]
-            Orbital V_ip = phi_p.paramCopy();
-            if (phi_ip.hasReal()) {
-                V_ip.alloc(NUMBER::Real);
-                mrcpp::apply(prec, V_ip.real(), P, phi_ip.real());
-            }
-            if (phi_ip.hasImag()) {
-                V_ip.alloc(NUMBER::Imag);
-                mrcpp::apply(prec, V_ip.imag(), P, phi_ip.imag());
-            }
-            phi_ip.release();
-
-            // compute phi_iip = phi_i * V_ip
-            Orbital phi_iip = phi_p.paramCopy();
-            qmfunction::multiply(phi_iip, phi_i, V_ip, -1.0);
-
-            coef_vec.push_back(spin_fac / phi_i.squaredNorm());
-            func_vec.push_back(phi_iip);
+        // compute V_ip = P[phi_ip]
+        Orbital V_ip = phi_p.paramCopy();
+        if (phi_ip.hasReal()) {
+            V_ip.alloc(NUMBER::Real);
+            mrcpp::apply(prec, V_ip.real(), P, phi_ip.real());
         }
+        if (phi_ip.hasImag()) {
+            V_ip.alloc(NUMBER::Imag);
+            mrcpp::apply(prec, V_ip.imag(), P, phi_ip.imag());
+        }
+        phi_ip.release();
+
+        // compute phi_iip = phi_i * V_ip
+        Orbital phi_iip = phi_p.paramCopy();
+        qmfunction::multiply(phi_iip, phi_i, V_ip, -1.0);
+
+        coef_vec.push_back(spin_fac / phi_i.squaredNorm());
+        func_vec.push_back(phi_iip);
+
+        if (!mpi::my_orb(phi_i)) phi_i.free(NUMBER::Total);
     }
 
     // compute ex_p = sum_i c_i*phi_iip
@@ -277,6 +274,75 @@ void ExchangePotentialD1::calcInternal(int i, int j) {
     // compute x_i += phi_jij
     Ex[i].add(spinFactor, phi_jij);
     phi_jij.release();
+}
+
+/** @brief computes the off-diagonal part of the exchange potential
+ *
+ *  \param[in] i first orbital index
+ *  \param[in] j second orbital index
+ *
+ * The off-diagonal terms K_ij and K_ji are computed.
+ */
+void ExchangePotentialD1::calcInternal(int i, int j, Orbital &phi_i, Orbital &phi_j) {
+    mrcpp::PoissonOperator &P = *this->poisson;
+    OrbitalVector &Phi = *this->orbitals;
+    OrbitalVector &Ex = this->exchange;
+
+    if (i == j) MSG_ABORT("Cannot handle diagonal term");
+    if (Ex.size() != Phi.size()) MSG_ABORT("Size mismatch");
+    if (phi_i.hasImag() or phi_j.hasImag()) MSG_ABORT("Orbitals must be real");
+
+    double i_fac = getSpinFactor(phi_i, phi_j);
+    double j_fac = getSpinFactor(phi_j, phi_i);
+
+    double thrs = mrcpp::MachineZero;
+    if (std::abs(i_fac) < thrs or std::abs(j_fac) < thrs) {
+        this->part_norms(i, j) = 0.0;
+        return;
+    }
+
+    // set correctly scaled precision for components ij and ji
+    double prec = std::min(getScaledPrecision(i, j), getScaledPrecision(j, i));
+    if (prec > 1.0e00) return;     // orbital does not contribute within the threshold
+    prec = std::min(prec, 1.0e-1); // very low precision does not work properly
+
+    // compute phi_ij = phi_i^dag * phi_j (dagger NOT used, orbitals must be real!)
+    Orbital phi_ij = phi_i.paramCopy();
+    qmfunction::multiply(phi_ij, phi_i, phi_j, prec);
+
+    // compute V_ij = P[phi_ij]
+    Orbital V_ij = phi_i.paramCopy();
+    if (phi_ij.hasReal()) {
+        V_ij.alloc(NUMBER::Real);
+        mrcpp::apply(prec, V_ij.real(), P, phi_ij.real());
+    }
+    if (phi_ij.hasImag()) {
+        MSG_ABORT("Orbitals must be real");
+        V_ij.alloc(NUMBER::Imag);
+        mrcpp::apply(prec, V_ij.imag(), P, phi_ij.imag());
+    }
+    phi_ij.release();
+
+    // compute phi_jij = phi_j * V_ij
+    Orbital phi_jij = phi_j.paramCopy();
+    qmfunction::multiply(phi_jij, phi_j, V_ij, prec);
+    phi_jij.rescale(1.0 / phi_j.squaredNorm());
+    this->part_norms(j, i) = phi_jij.norm();
+
+    // compute phi_iij = phi_i * V_ij
+    Orbital phi_iij = phi_i.paramCopy();
+    qmfunction::multiply(phi_iij, phi_i, V_ij, prec);
+    phi_iij.rescale(1.0 / phi_i.squaredNorm());
+    this->part_norms(i, j) = phi_iij.norm();
+    V_ij.release();
+
+    // compute x_i += phi_jij
+    Ex[i].add(i_fac, phi_jij);
+    phi_jij.release();
+
+    // compute x_j += phi_iij
+    Ex[j].add(j_fac, phi_iij);
+    phi_iij.release();
 }
 
 } // namespace mrchem

--- a/src/qmoperators/two_electron/ExchangePotentialD1.h
+++ b/src/qmoperators/two_electron/ExchangePotentialD1.h
@@ -37,6 +37,7 @@ private:
     Orbital calcExchange(Orbital phi_p);
     void calcInternal(int i);
     void calcInternal(int i, int j);
+    void calcInternal(int i, int j, Orbital &phi_i, Orbital &phi_j);
 };
 
 } // namespace mrchem


### PR DESCRIPTION
This version runs in parallel. The "new integrals" are not included yet, so it should work also with normal mrcpp.
The most important parts are:

in `ExchangePotentialD2::setupInternal`

`if (mpi::my_orb(Phi[i])) mpi::orb_bank.put_orb(i, Phi[i]);`
`if (mpi::my_orb(X[i])) mpi::orb_bank.put_orb(i + Phi.size(), X[i]);`

and in ExchangePotentialD2::calcExchange_X
`if (!mpi::my_orb(phi_i)) mpi::orb_bank.get_orb(i, phi_i);`
`if (!mpi::my_orb(x_i)) mpi::orb_bank.get_orb(i + Phi.size(), x_i);`

Also, most of the efforts were to repair the "normal" exchange :)